### PR TITLE
Update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In order to customize `mobx-log` use `configureMakeLoggable` function.
 import { configureMakeLoggable } from 'mobx-log';
 
 configureMakeLoggable({
-  storeBrowserAccess: true,
+  storeConsoleAccess: true,
 });
 ```
 


### PR DESCRIPTION
The previous key name "storeBrowserAccess" was apparently updated to "storeConsoleAccess", because the former produces the following error:
```
Argument of type '{ storeBrowserAccess: boolean; }' is not assignable to parameter of type 'Partial<Config>'.
  Object literal may only specify known properties, and 'storeBrowserAccess' does not exist in type 'Partial<Config>'.ts(2345)
```