### PR TITLE
Use constructor name instead of just 'Object'

### DIFF
--- a/src/chrome-formatters.ts
+++ b/src/chrome-formatters.ts
@@ -71,7 +71,7 @@ const renderIterableBody = (
 export class ObjectFormatter implements ChromeFormatter<{}> {
   header(argument: {}): Header | null {
     return isObservableObject(argument)
-      ? renderIterableHeader(Object.keys(argument), 'Object')
+      ? renderIterableHeader(Object.keys(argument), argument?.constructor.name ?? 'Object')
       : null;
   }
 


### PR DESCRIPTION
Предлагаю для объектов заменять стандартное "Object" на название их конструктора для наглядности:

![image](https://user-images.githubusercontent.com/1235286/160905664-cb553024-0cf8-475a-ba8e-d146ec40420e.png)
