### PR TITLE
fix/check-for-window-presence

### DIFF
--- a/src/make-loggable.ts
+++ b/src/make-loggable.ts
@@ -32,7 +32,7 @@ export const makeLoggable = <T extends {}>(
   store: T,
   perStoreConfig?: PerStoreFilters
 ): T => {
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV === 'production' || typeof window === 'undefined') {
     return store;
   }
 


### PR DESCRIPTION
fix: skip make-loggable execution when there is no window

* In node.js environments like server-side next.js there is no `window`,
  so we must check for it so that `makeLoggable` does not cause an error